### PR TITLE
fix: use newer API to create image and ensure size is not zero

### DIFF
--- a/BVLinearGradient/BVLinearGradientLayer.m
+++ b/BVLinearGradient/BVLinearGradientLayer.m
@@ -50,19 +50,38 @@
 
     BOOL hasAlpha = NO;
 
-    for (NSInteger i = 0; i < self.colors.count; i++) {
-        hasAlpha = hasAlpha || CGColorGetAlpha(self.colors[i].CGColor) < 1.0;
+    CGSize size = self.bounds.size;
+    if (size.width <= 0 || size.height <= 0) {
+        return;
     }
 
-    UIGraphicsBeginImageContextWithOptions(self.bounds.size, !hasAlpha, 0.0);
-    CGContextRef ref = UIGraphicsGetCurrentContext();
-    [self drawInContext:ref];
+    if (@available(iOS 10.0, *)) {
+        UIGraphicsImageRendererFormat *format;
+        if (@available(iOS 11.0, *)) {
+            format = [UIGraphicsImageRendererFormat preferredFormat];
+        } else {
+            format = [UIGraphicsImageRendererFormat defaultFormat];
+        }
+        format.opaque = !hasAlpha;
+        
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:self.bounds.size format:format];
+        UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull ref) {
+            [self drawInContext:ref.CGContext];
+        }];
 
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    self.contents = (__bridge id _Nullable)(image.CGImage);
-    self.contentsScale = image.scale;
+        self.contents = (__bridge id _Nullable)(image.CGImage);
+        self.contentsScale = image.scale;
+    } else {
+        UIGraphicsBeginImageContextWithOptions(self.bounds.size, !hasAlpha, 0.0);
+        CGContextRef ref = UIGraphicsGetCurrentContext();
+        [self drawInContext:ref];
 
-    UIGraphicsEndImageContext();
+        UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+        self.contents = (__bridge id _Nullable)(image.CGImage);
+        self.contentsScale = image.scale;
+
+        UIGraphicsEndImageContext();
+    }
 }
     
 - (void)setUseAngle:(BOOL)useAngle

--- a/BVLinearGradient/BVLinearGradientLayer.m
+++ b/BVLinearGradient/BVLinearGradientLayer.m
@@ -48,11 +48,15 @@
 - (void)display {
     [super display];
 
-    BOOL hasAlpha = NO;
-
     CGSize size = self.bounds.size;
     if (size.width <= 0 || size.height <= 0) {
         return;
+    }
+
+    BOOL hasAlpha = NO;
+
+    for (NSInteger i = 0; i < self.colors.count; i++) {
+        hasAlpha = hasAlpha || CGColorGetAlpha(self.colors[i].CGColor) < 1.0;
     }
 
     if (@available(iOS 10.0, *)) {


### PR DESCRIPTION
old API is deprecated and is causing some crashes. Switch to the new API (https://github.com/react-native-linear-gradient/react-native-linear-gradient/commit/ffe4a4c72b4aaf7969a49c62c267e4a1eb88fa4b) and add a check to ensure size is not 0